### PR TITLE
enhancements to Gauss prior deconvolution

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -409,7 +409,7 @@ def DNP_Gauss_freq(image, psf, smoothness_weight=0.01, clip=True):
 
     Examples
     --------
-    >>> from skimage import image_as_float, data, restoration
+    >>> from skimage import img_as_float, data, restoration
     >>> camera = img_as_float(data.camera())
     >>> from scipy.signal import convolve2d
     >>> psf = np.ones((5, 5)) / 25

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -441,10 +441,6 @@ def DNP_Gauss_freq(image, psf, smoothness_weight=0.01, clip=True):
     psf = psf.astype(float_type, copy=False)
 
     n, m = image.shape
-    # psf.shape() is expected to be odd in both dimension but works with even
-    # too.
-    # not sure if the double flip is needed
-    psf = np.fliplr(np.flipud(psf))
 
     # force some shapes
     onesrow = np.array([-1, 1])

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -439,6 +439,10 @@ def DNP_Gauss_freq(image, psf, smoothness_weight=0.01, clip=True):
     float_type = np.promote_types(image.dtype, np.float32)
     image = image.astype(float_type, copy=False)
     psf = psf.astype(float_type, copy=False)
+    if image.ndim != psf.ndim:
+        raise ValueError(
+          "psf and image must have an equal number of dimensions"
+        )
 
     shape = image.shape
 

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -447,16 +447,16 @@ def DNP_Gauss_freq(image, psf, smoothness_weight=0.01, clip=True):
     onesrow.shape = (1, 2)
     onescol = np.array([-1, 1])
     onescol.shape = (2, 1)
-    Gx = fft.fft2(onesrow, s=(n, m))
-    Gy = fft.fft2(onescol, s=(n, m))
-    F = fft.fft2(psf, s=(n, m))
+    Gx = fft.rfft2(onesrow, s=(n, m))
+    Gy = fft.rfft2(onescol, s=(n, m))
+    F = fft.rfft2(psf, s=(n, m))
 
     A = np.conj(F) * F + smoothness_weight * (np.conj(Gx) * Gx
                                               + np.conj(Gy) * Gy)
-    b = np.conj(F) * fft.fft2(image)
+    b = np.conj(F) * fft.rfft2(image)
 
     X = np.divide(b, A)
-    x = np.real(fft.ifft2(X))
+    x = np.real(fft.irfft2(X))
 
     nf, mf = psf.shape
     hs1 = (nf - 1) // 2


### PR DESCRIPTION
This PR adds a few commits that improve the performance of deconvolution and extend the support to n-dimensional image and psf.

I also added the ability to optionally pad the input using a `pad_width` argument, to reduce artifacts at the edges.

I was not 100% sure about this PSF flip, but an empirical test seems to indicate that it should not be there. Specifically, try running demo with a non-symmetric PSF and then subtract the deconvolved result from the original image. With the PSF flip I get a lot of edge content due to a spatial shift, but without the flip it looks much better.

example
```Python
import numpy as np
from skimage import img_as_float, data, restoration
from scipy.ndimage import convolve
import matplotlib.pyplot as plt

camera = img_as_float(data.camera())
psf = np.zeros((7, 7))
psf[2:, 2:] = 1
psf /= psf.sum()
camera = convolve(camera, psf)
camera += 0.1 * camera.std() * np.random.standard_normal(camera.shape)
deconvolved = restoration.DNP_Gauss_freq(camera, psf)

plt.figure()
plt.imshow(deconvolved - img_as_float(data.camera()))
```

Below are results before and after removal of the flip:
![psf_flip](https://user-images.githubusercontent.com/6528957/97533289-58280400-198e-11eb-92c5-6d6dc3638354.png)
![psf_no_flip](https://user-images.githubusercontent.com/6528957/97533299-5b22f480-198e-11eb-94fb-19f36dda3558.png)


adding `pad_width=16` in the script above would also remove much of the ringing artifact at the boundary.
